### PR TITLE
Replace 'false' event handlers with 'undefined'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,13 +113,13 @@ export default class PullRefresh extends Component {
         <Container
           ref='container'
           {...props}
-          onScroll    ={!disabled && ::this.onScroll}
-          onMouseDown ={!disabled && ::this.onDown}
-          onMouseUp   ={!disabled && ::this.onUp}
-          onMouseMove ={!disabled && ::this.onMove}
-          onTouchStart={!disabled && ::this.onDown}
-          onTouchEnd  ={!disabled && ::this.onUp}
-          onTouchMove ={!disabled && ::this.onMove}
+          onScroll    ={disabled ? undefined : ::this.onScroll}
+          onMouseDown ={disabled ? undefined : ::this.onDown}
+          onMouseUp   ={disabled ? undefined : ::this.onUp}
+          onMouseMove ={disabled ? undefined : ::this.onMove}
+          onTouchStart={disabled ? undefined : ::this.onDown}
+          onTouchEnd  ={disabled ? undefined : ::this.onUp}
+          onTouchMove ={disabled ? undefined : ::this.onMove}
         >
           { children }
         </Container>


### PR DESCRIPTION
It seems the browser doesn't appreciate "false" as an event handler. When i set the `disabled` prop to true I get the following error in the console:

```
Warning: Expected `onScroll` listener to be a function, instead got `false`.
If you used to conditionally omit it with onScroll={condition && value}, pass onScroll={condition ? value : undefined} instead.
    in div (created by styled.div)
    in styled.div (created by PullRefresh)
    in PullRefresh (at StandbyView.js:25)
    in StandbyView (created by DragDropContext(StandbyView))
    in DragDropContext(StandbyView) (created by Connect(DragDropContext(StandbyView)))
    in Connect(DragDropContext(StandbyView)) (at App.js:31)
    in div (at App.js:30)
    in div (at App.js:27)
    in div (at App.js:25)
    in MuiThemeProvider (created by MuiThemeProviderWrapper)
    in MuiThemeProviderWrapper (at App.js:24)
    in App (created by Connect(App))
    in Connect(App) (at index.js:22)
    in Provider (at index.js:21)
```
Fortunately the message already delivers the solution. I implemented the small changes in this pull request.

Thank you very much for your work!

Best Regards